### PR TITLE
Fix uppercase ACR name in init script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,7 @@
 echo "Defining variables..."
 export RESOURCE_GROUP_NAME=mslearn-gh-pipelines-$RANDOM
 export AKS_NAME=contoso-video
-export ACR_NAME=ContosoContainerRegistry$RANDOM
+export ACR_NAME=contosocontainerregistry$RANDOM
 
 echo "Searching for resource group..."
 az group create -n $RESOURCE_GROUP_NAME -l eastus


### PR DESCRIPTION
Creating an ACR with the script previously throws an error because the name of the ACR has uppercase letters.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/95448438/162044071-42978151-d2f7-4bc6-b841-8ef4760e637f.png">
